### PR TITLE
Added preliminary MacOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # pg_paper_dump
 Modern Analog Data Preservation
 
-## Getting started
+## Getting Started
 
 ```
 $ pg_dump -U username -W -F c -b -v -f "/path/to/your/backup/file.backup" dbname
 ```
+### Windows
 
-Open file.backup in the text editor of your choice (e.g. Windows Notepad) and press CTRL+P.
+To export your database dump to paper on Windows, open the .backup file in your favourite text editor, like Notepad, and hit CTRL+P to begin the export.
+
+### MacOS - Experimental
+
+While MacOS is not officially supported, you can still achieve a successfull export of your backup using the TextEdit app, and the CMD+P shortcut.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #1, allowing successful paper exports on MacOS.

## What is the current behavior?

MacOS is currently unsupported, excluding a large portion of Supabase users from utilising this new feature.

## What is the new behavior?

Instructions and considerations have been given for MacOS users, allowing successful paper-based exports.

## Additional context

As I am not a MacOS user, and I created this pull request from my phone at 1am, considering these instructions untested :) 
